### PR TITLE
add ExchangeOrderResult.UpdateSequence

### DIFF
--- a/src/ExchangeSharp/API/Exchanges/BinanceGroup/Models/UserDataStream.cs
+++ b/src/ExchangeSharp/API/Exchanges/BinanceGroup/Models/UserDataStream.cs
@@ -94,6 +94,7 @@ namespace ExchangeSharp.BinanceGroup
 					OrderDate = CryptoUtility.UnixTimeStampToDateTimeMilliseconds(OrderCreationTime),
 					CompletedDate = status.IsCompleted() ? (DateTime?)CryptoUtility.UnixTimeStampToDateTimeMilliseconds(TransactionTime) : null,
 					TradeDate = CryptoUtility.UnixTimeStampToDateTimeMilliseconds(TransactionTime),
+					UpdateSequence = EventTime, // in Binance, the sequence nymber is also the EventTime
 					MarketSymbol = Symbol,
 					// IsBuy is not provided here
 					Fees = CommissionAmount,

--- a/src/ExchangeSharp/API/Exchanges/Coinbase/Models/Response/Messages.cs
+++ b/src/ExchangeSharp/API/Exchanges/Coinbase/Models/Response/Messages.cs
@@ -22,8 +22,6 @@ namespace ExchangeSharp.Coinbase
 
 	internal class Activate : BaseMessage
 	{
-		private ExchangeOrderResult exchangeOrderResult;
-
 		public Guid OrderId { get; set; }
 		public StopType OrderType { get; set; }
 		public decimal Size { get; set; }
@@ -52,7 +50,8 @@ namespace ExchangeSharp.Coinbase
 			MarketSymbol = ProductId,
 			IsBuy = Side == OrderSide.Buy,
 			Fees = null, // only TakerFeeRate is specified - no fees have been charged yet
-			TradeId = null // no trades have been made
+			TradeId = null, // no trades have been made
+			UpdateSequence = null, // unfortunately, the Activate event doesn't provide a sequence number
 		};
 	}
 
@@ -84,7 +83,8 @@ namespace ExchangeSharp.Coinbase
 			MarketSymbol = ProductId,
 			IsBuy = Side == OrderSide.Buy,
 			Fees = null, // only TakerFeeRate is specified - no fees have been charged yet
-			TradeId = null // not a trade msg
+			TradeId = null, // not a trade msg
+			UpdateSequence = Sequence,
 		};
 	}
 
@@ -116,7 +116,8 @@ namespace ExchangeSharp.Coinbase
 			MarketSymbol = ProductId,
 			IsBuy = Side == OrderSide.Buy,
 			Fees = null, // not specified here
-			TradeId = null // not a trade msg
+			TradeId = null, // not a trade msg
+			UpdateSequence = Sequence,
 		};
 	}
 
@@ -189,6 +190,7 @@ namespace ExchangeSharp.Coinbase
 			IsBuy = Side == OrderSide.Buy,
 			Fees = (MakerFeeRate ?? TakerFeeRate) * Price * Size,
 			TradeId = TradeId.ToString(),
+			UpdateSequence = Sequence,
 		};
 	}
 
@@ -218,7 +220,8 @@ namespace ExchangeSharp.Coinbase
 			MarketSymbol = ProductId,
 			IsBuy = Side == OrderSide.Buy,
 			Fees = null, // not specified here
-			TradeId = null // not a trade msg
+			TradeId = null, // not a trade msg
+			UpdateSequence = Sequence,
 		};
 	}
 
@@ -250,7 +253,8 @@ namespace ExchangeSharp.Coinbase
 			MarketSymbol = ProductId,
 			IsBuy = Side == OrderSide.Buy,
 			Fees = null, // not specified here
-			TradeId = null // not a trade msg
+			TradeId = null, // not a trade msg
+			UpdateSequence = Sequence,
 		};
 	}
 

--- a/src/ExchangeSharp/Model/ExchangeOrderResult.cs
+++ b/src/ExchangeSharp/Model/ExchangeOrderResult.cs
@@ -91,6 +91,12 @@ namespace ExchangeSharp
 		/// <summary>datetime in UTC of the trade. Null if not a trade.</summary>
 		public DateTime? TradeDate { get; set; }
 
+		/// <summary>
+		/// sequence that the order update was sent from the server, usually used to keep updates in order or for debugging purposes.
+		/// Not all exchanges provide this value, so it may be null.
+		/// </summary>
+		public long? UpdateSequence { get; set; }
+
 		/// <summary>Append another order to this order - order id and type must match</summary>
 		/// <param name="other">Order to append</param>
 		public void AppendOrderWithOrder(ExchangeOrderResult other)


### PR DESCRIPTION
- sequence that the order update was sent from the server, usually used to keep updates in order or for debugging purposes