### PR TITLE
rename `master` branch to `main`

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Exchange constructors are private, to get access to an exchange in code use:
 
 On \*nix systems:
 
-- Run this command `curl https://github.com/jjxtra/ExchangeSharp/raw/master/install-console.sh | sh`
+- Run this command `curl https://github.com/DigitalRuby/ExchangeSharp/raw/main/install-console.sh | sh`
 
 On Windows (or manually):
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@ trigger:
   batch: false
   branches:
     include:
-    - master
+    - main
   paths:
     exclude:
     - .github/**
@@ -17,7 +17,7 @@ pr:
   autoCancel: true
   branches:
     include:
-    - master
+    - main
   paths:
     exclude:
     - .github/**
@@ -30,7 +30,7 @@ schedules:
   displayName: Monthly release
   branches:
     include:
-    - master
+    - main
 
 variables:
   BuildConfiguration: 'Release'


### PR DESCRIPTION
- part of preparation for next release