### PR TITLE
update projects to `.net 8.0`

### DIFF
--- a/examples/ExchangeSharpWinForms/ExchangeSharpWinForms.csproj
+++ b/examples/ExchangeSharpWinForms/ExchangeSharpWinForms.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ProjectGuid>{571623F9-1652-4669-8E17-A6FAD1426181}</ProjectGuid>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <AssemblyTitle>ExchangeSharpWinForms</AssemblyTitle>
     <Product>ExchangeSharpWinForms</Product>

--- a/src/ExchangeSharp.Forms/ExchangeSharp.Forms.csproj
+++ b/src/ExchangeSharp.Forms/ExchangeSharp.Forms.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0-windows</TargetFramework>
+        <TargetFramework>net8.0-windows</TargetFramework>
         <DefineConstants>HAS_WINDOWS_FORMS</DefineConstants>
         <NeutralLanguage>en</NeutralLanguage>
 		<UseWindowsForms>true</UseWindowsForms>

--- a/src/ExchangeSharp/API/Exchanges/Bitflyer/ExchangeBitflyerApi.cs
+++ b/src/ExchangeSharp/API/Exchanges/Bitflyer/ExchangeBitflyerApi.cs
@@ -161,11 +161,11 @@ namespace ExchangeSharp
 
 	class SocketIOWrapper : IWebSocket
 	{
-		public SocketIO socketIO;
+		public SocketIOClient.SocketIO socketIO;
 
 		public SocketIOWrapper(string url)
 		{
-			socketIO = new SocketIO(url);
+			socketIO = new SocketIOClient.SocketIO(url);
 			socketIO.Options.Transport = SocketIOClient.Transport.TransportProtocol.WebSocket;
 			socketIO.OnConnected += (s, e) => Connected?.Invoke(this);
 			socketIO.OnDisconnected += (s, e) => Disconnected?.Invoke(this);

--- a/src/ExchangeSharpConsole/ExchangeSharpConsole.csproj
+++ b/src/ExchangeSharpConsole/ExchangeSharpConsole.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AssemblyName>exchange-sharp</AssemblyName>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NeutralLanguage>en</NeutralLanguage>
     <AssemblyVersion>1.0.4</AssemblyVersion>
     <FileVersion>1.0.4</FileVersion>

--- a/tests/ExchangeSharpTests/ExchangeCoinbaseAPITests.cs
+++ b/tests/ExchangeSharpTests/ExchangeCoinbaseAPITests.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using ExchangeSharp;
-using ExchangeSharp.Coinbase;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
@@ -26,22 +25,6 @@ namespace ExchangeSharpTests
 			)!;
 			api.RequestMaker = requestMaker;
 			return api;
-		}
-
-		[TestMethod]
-		public void DeserializeUserMatch()
-		{
-			string toParse =
-					"{\r\n  \"type\": \"match\",\r\n  \"trade_id\": 10,\r\n  \"sequence\": 50,\r\n  \"maker_order_id\": \"ac928c66-ca53-498f-9c13-a110027a60e8\",\r\n  \"taker_order_id\": \"132fb6ae-456b-4654-b4e0-d681ac05cea1\",\r\n  \"time\": \"2014-11-07T08:19:27.028459Z\",\r\n  \"product_id\": \"BTC-USD\",\r\n  \"size\": \"5.23512\",\r\n  \"price\": \"400.23\",\r\n  \"side\": \"sell\"\r\n,\r\n  \"taker_user_id\": \"5844eceecf7e803e259d0365\",\r\n  \"user_id\": \"5844eceecf7e803e259d0365\",\r\n  \"taker_profile_id\": \"765d1549-9660-4be2-97d4-fa2d65fa3352\",\r\n  \"profile_id\": \"765d1549-9660-4be2-97d4-fa2d65fa3352\",\r\n  \"taker_fee_rate\": \"0.005\"\r\n}";
-
-			var usermatch = JsonConvert.DeserializeObject<Match>(
-					toParse,
-					BaseAPI.SerializerSettings
-			);
-			usermatch.MakerOrderId.Should().Be("ac928c66-ca53-498f-9c13-a110027a60e8");
-			usermatch.ExchangeOrderResult.OrderId
-					.Should()
-					.Be("132fb6ae-456b-4654-b4e0-d681ac05cea1");
 		}
 	}
 }

--- a/tests/ExchangeSharpTests/ExchangePoloniexAPITests.cs
+++ b/tests/ExchangeSharpTests/ExchangePoloniexAPITests.cs
@@ -285,7 +285,7 @@ namespace ExchangeSharpTests
 					@"{""error"":""Order not found, or you are not the person who placed it.""}";
 			var polo = await CreatePoloniexAPI(response);
 			async Task a() => await polo.GetOrderDetailsAsync("1");
-			Invoking(a).Should().Throw<APIException>();
+			await Invoking(a).Should().ThrowAsync<APIException>();
 		}
 
 		[TestMethod]
@@ -295,7 +295,7 @@ namespace ExchangeSharpTests
 			var polo = await CreatePoloniexAPI(response);
 
 			async Task a() => await polo.GetOrderDetailsAsync("1");
-			Invoking(a).Should().Throw<APIException>();
+			await Invoking(a).Should().ThrowAsync<APIException>();
 		}
 
 		[TestMethod]

--- a/tests/ExchangeSharpTests/ExchangeSharpTests.csproj
+++ b/tests/ExchangeSharpTests/ExchangeSharpTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NeutralLanguage>en</NeutralLanguage>
     <AssemblyVersion>1.0.4</AssemblyVersion>
@@ -17,13 +17,19 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.2.0" />
-    <PackageReference Include="FluentAssertions.Analyzers" Version="0.11.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.2.1" />
-    <PackageReference Include="NSubstitute" Version="3.1.0" />
-    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.10" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="FluentAssertions.Analyzers" Version="0.29.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.16">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- only sub-projects are `.net 8.0`, the main `ExchangeSharp` is still `.net standard 2.0`
- updated dependencies in `ExchangeSharpTests`
- fix compilation errors in `ExchangeSharpTests` and `ExchangeBitflyerApi.cs`
      - removed outdated Coinbase test, now that Coinbase has been rewritten