### PR TITLE
Change the default Kraken request method to GET

### DIFF
--- a/src/ExchangeSharp/API/Exchanges/Kraken/ExchangeKrakenAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Kraken/ExchangeKrakenAPI.cs
@@ -34,7 +34,6 @@ namespace ExchangeSharp
 
 		private ExchangeKrakenAPI()
 		{
-			RequestMethod = "POST";
 			RequestContentType = "application/x-www-form-urlencoded";
 			MarketSymbolSeparator = string.Empty;
 			NonceStyle = NonceStyle.UnixMilliseconds;


### PR DESCRIPTION
As of yesterday, Kraken has dropped support for POST requests to GET endpoints. Now in these cases, a status code of 405 (Method not allowed) is returned.

> Jan 2024 - Removed support for POST requests to all public endpoints; these requests will now return a 4xx error, please use a GET request instead. Added notes to Balance and Ledger endpoints on migration from Staking to Earn and asset suffixes.

(https://docs.kraken.com/rest/#section/Changelog)

This caused most methods (such as `GetOrderBookAsync`) to no longer work.