### PR TITLE
Implement KuCoin orderbook WebSocket listener

### DIFF
--- a/src/ExchangeSharp/API/Exchanges/Kraken/ExchangeKrakenAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Kraken/ExchangeKrakenAPI.cs
@@ -1484,7 +1484,7 @@ namespace ExchangeSharp
 		/// <returns></returns>
 		protected override async Task<IWebSocket> OnGetDeltaOrderBookWebSocketAsync(
 				Action<ExchangeOrderBook> callback,
-				int maxCount = 20,
+				int maxCount = 100,
 				params string[] marketSymbols
 		)
 		{
@@ -1639,7 +1639,7 @@ namespace ExchangeSharp
 						{
 							Event = ActionType.Subscribe,
 							Pairs = marketSymbols.ToList(),
-							SubscriptionSettings = new Subscription { Name = "book", Depth = 100 }
+							SubscriptionSettings = new Subscription { Name = "book", Depth = maxCount }
 						};
 						await _socket.SendMessageAsync(channelAction);
 					}

--- a/src/ExchangeSharp/API/Exchanges/_Base/ExchangeAPIExtensions.cs
+++ b/src/ExchangeSharp/API/Exchanges/_Base/ExchangeAPIExtensions.cs
@@ -45,7 +45,7 @@ namespace ExchangeSharp
 		public static async Task<IWebSocket> GetFullOrderBookWebSocketAsync(
 				this IOrderBookProvider api,
 				Action<ExchangeOrderBook> callback,
-				int maxCount = 20,
+				int maxCount = 100,
 				params string[] symbols
 		)
 		{


### PR DESCRIPTION
### Changes
1. Implementation of the steps described in the KuCoin docs: https://www.kucoin.com/docs/websocket/spot-trading/public-channels/level2-market-data
2. Updated `OnGetDeltaOrderBookWebSocketAsync` from Kraken to use the `maxCount` parameter, instead of the hardcoded `100` (also, it turned out that the default `20` was not a supported depth)