### PR TITLE
Binance - Use the NOTIONAL filter to get the min trade size in quote currency

### DIFF
--- a/src/ExchangeSharp/API/Exchanges/BinanceGroup/BinanceGroupCommon.cs
+++ b/src/ExchangeSharp/API/Exchanges/BinanceGroup/BinanceGroupCommon.cs
@@ -270,13 +270,18 @@ namespace ExchangeSharp.BinanceGroup
 					market.PriceStepSize = priceFilter["tickSize"].ConvertInvariant<decimal>();
 				}
 
-				// MIN_NOTIONAL
-				JToken? minNotionalFilter = filters?.FirstOrDefault(
+				// NOTIONAL or MIN_NOTIONAL
+				JToken? notionalFilter =
+					filters?.FirstOrDefault(
+						x => string.Equals(x["filterType"].ToStringUpperInvariant(), "NOTIONAL")
+					)
+					??
+					filters?.FirstOrDefault(
 						x => string.Equals(x["filterType"].ToStringUpperInvariant(), "MIN_NOTIONAL")
-				);
-				if (minNotionalFilter != null)
+					);
+				if (notionalFilter != null)
 				{
-					market.MinTradeSizeInQuoteCurrency = minNotionalFilter[
+					market.MinTradeSizeInQuoteCurrency = notionalFilter[
 							"minNotional"
 					].ConvertInvariant<decimal>();
 				}


### PR DESCRIPTION
Because using `MIN_NOTIONAL` alone would result in `MinTradeSizeInQuoteCurrency` being always null (as far as I've tested). `MIN_NOTIONAL` is now used as a fallback.

https://binance-docs.github.io/apidocs/spot/en/#notional (fairly new filter, introduced on `2022-06-15`)

Sample market metadata response used for reference:

```
{{
  "symbol": "ETHUSDT",
  "status": "TRADING",
  "baseAsset": "ETH",
  "baseAssetPrecision": 8,
  "quoteAsset": "USDT",
  "quotePrecision": 8,
  "quoteAssetPrecision": 8,
  "baseCommissionPrecision": 8,
  "quoteCommissionPrecision": 8,
  "orderTypes": [
    "LIMIT",
    "LIMIT_MAKER",
    "MARKET",
    "STOP_LOSS_LIMIT",
    "TAKE_PROFIT_LIMIT"
  ],
  "icebergAllowed": true,
  "ocoAllowed": true,
  "quoteOrderQtyMarketAllowed": true,
  "allowTrailingStop": true,
  "cancelReplaceAllowed": true,
  "isSpotTradingAllowed": true,
  "isMarginTradingAllowed": true,
  "filters": [
    {
      "filterType": "PRICE_FILTER",
      "minPrice": "0.01000000",
      "maxPrice": "1000000.00000000",
      "tickSize": "0.01000000"
    },
    {
      "filterType": "LOT_SIZE",
      "minQty": "0.00010000",
      "maxQty": "9000.00000000",
      "stepSize": "0.00010000"
    },
    {
      "filterType": "ICEBERG_PARTS",
      "limit": 10
    },
    {
      "filterType": "MARKET_LOT_SIZE",
      "minQty": "0.00000000",
      "maxQty": "2025.64664208",
      "stepSize": "0.00000000"
    },
    {
      "filterType": "TRAILING_DELTA",
      "minTrailingAboveDelta": 10,
      "maxTrailingAboveDelta": 2000,
      "minTrailingBelowDelta": 10,
      "maxTrailingBelowDelta": 2000
    },
    {
      "filterType": "PERCENT_PRICE_BY_SIDE",
      "bidMultiplierUp": "5",
      "bidMultiplierDown": "0.2",
      "askMultiplierUp": "5",
      "askMultiplierDown": "0.2",
      "avgPriceMins": 5
    },
    {
      "filterType": "NOTIONAL",
      "minNotional": "5.00000000",
      "applyMinToMarket": true,
      "maxNotional": "9000000.00000000",
      "applyMaxToMarket": false,
      "avgPriceMins": 5
    },
    {
      "filterType": "MAX_NUM_ORDERS",
      "maxNumOrders": 200
    },
    {
      "filterType": "MAX_NUM_ALGO_ORDERS",
      "maxNumAlgoOrders": 5
    }
  ],
  "permissions": [
    "SPOT",
    "MARGIN",
    "TRD_GRP_004",
    "TRD_GRP_005",
    "TRD_GRP_006",
    "TRD_GRP_009",
    "TRD_GRP_010",
    "TRD_GRP_011",
    "TRD_GRP_012",
    "TRD_GRP_013",
    "TRD_GRP_014",
    "TRD_GRP_015",
    "TRD_GRP_016",
    "TRD_GRP_017",
    "TRD_GRP_018",
    "TRD_GRP_019",
    "TRD_GRP_020",
    "TRD_GRP_021",
    "TRD_GRP_022",
    "TRD_GRP_023",
    "TRD_GRP_024",
    "TRD_GRP_025"
  ],
  "defaultSelfTradePreventionMode": "EXPIRE_MAKER",
  "allowedSelfTradePreventionModes": [
    "EXPIRE_TAKER",
    "EXPIRE_MAKER",
    "EXPIRE_BOTH"
  ]
}}
```