### PR TITLE
Reset cached orderbook when new orderbook is a snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The following cryptocurrency exchanges are supported:
 | Bleutrade           | x           | x            |               |                                             |
 | BtcTurk             |             |              |   R           |                                             |
 | BTSE                | x           | x            |               |                                             |
-| Bybit               | x           | x            |   R           | Has public method for Websocket Positions   |
+| Bybit               | x           | x            |   R B         | Has public method for Websocket Positions   |
 | Coinbase (Advanced) | x           | x            | T R   O U     |                                             |
 | Coincheck           |             |              |   R           |                                             |
 | Coinmate            | x           | x            |               |                                             |
@@ -57,7 +57,7 @@ The following cryptocurrency exchanges are supported:
 | HitBTC              | x           | x            |   R           |                                             |
 | Huobi               | x           | x            |   R B         |                                             |
 | Kraken              | x           | x            |   R           | Dark order symbols not supported            |
-| KuCoin              | x           | x            | T R           |                                             |
+| KuCoin              | x           | x            | T R B         |                                             |
 | LBank               | x           | x            |   R           |                                             |
 | Livecoin            | x           | x            |               |                                             |
 | MEXC                | x           | x            |               |                                             |

--- a/src/ExchangeSharp/API/Exchanges/_Base/ExchangeAPIExtensions.cs
+++ b/src/ExchangeSharp/API/Exchanges/_Base/ExchangeAPIExtensions.cs
@@ -170,7 +170,7 @@ namespace ExchangeSharp
 						{
 							// First response from exchange will be the full order book.
 							// Subsequent updates will be deltas, at least some exchanges have their heads on straight
-							if (!foundFullBook)
+							if (!foundFullBook || newOrderBook.IsFromSnapshot)
 							{
 								fullBooks[newOrderBook.MarketSymbol] = fullOrderBook = newOrderBook;
 							}


### PR DESCRIPTION
This idea came while looking over Bybit's API:

> Once you have subscribed successfully, you will receive a snapshot. The WebSocket will keep pushing delta messages every time the orderbook changes. **If you receive a new snapshot message, you will have to reset your local orderbook.** If there is a problem on Bybit's end, a snapshot will be re-sent, which is guaranteed to contain the latest data.

https://bybit-exchange.github.io/docs/v5/websocket/public/orderbook#process-snapshotdelta

It seems like common sense to reset the old orderbook when the new one is a full one. Also, the impact would be very reduced because the only ones that set `IsFromSnapshot` to true are Bybit and KuCoin.

I've also updated the readme to reflect that Bybit and KuCoin have orderbook websockets implemented.