### PR TITLE
KuCoin, MEXC - Orderbook WebSockets improvements

### DIFF
--- a/src/ExchangeSharp/API/Exchanges/_Base/ExchangeAPIExtensions.cs
+++ b/src/ExchangeSharp/API/Exchanges/_Base/ExchangeAPIExtensions.cs
@@ -474,28 +474,48 @@ namespace ExchangeSharp
 				string sequence = "ts"
 		)
 		{
-			var book = new ExchangeOrderBook
+			var book = new ExchangeOrderBook();
+
+			if (token == null)
 			{
-				SequenceId = token[sequence].ConvertInvariant<long>()
-			};
-			foreach (var array in token[asks])
-			{
-				var depth = new ExchangeOrderPrice
-				{
-					Price = array[0].ConvertInvariant<decimal>(),
-					Amount = array[1].ConvertInvariant<decimal>()
-				};
-				book.Asks[depth.Price] = depth;
+				Logger.Warn($"Null token in {nameof(ParseOrderBookFromJTokenArrays)}");
+				return book;
 			}
 
-			foreach (var array in token[bids])
+			book.SequenceId = token[sequence].ConvertInvariant<long>();
+
+			if (token[asks] != null)
 			{
-				var depth = new ExchangeOrderPrice
+				foreach (var array in token[asks])
 				{
-					Price = array[0].ConvertInvariant<decimal>(),
-					Amount = array[1].ConvertInvariant<decimal>()
-				};
-				book.Bids[depth.Price] = depth;
+					var depth = new ExchangeOrderPrice
+					{
+						Price = array[0].ConvertInvariant<decimal>(),
+						Amount = array[1].ConvertInvariant<decimal>()
+					};
+					book.Asks[depth.Price] = depth;
+				}
+			}
+			else
+			{
+				Logger.Warn($"No asks in {nameof(ParseOrderBookFromJTokenArrays)}");
+			}
+
+			if (token[bids] != null)
+			{
+				foreach (var array in token[bids])
+				{
+					var depth = new ExchangeOrderPrice
+					{
+						Price = array[0].ConvertInvariant<decimal>(),
+						Amount = array[1].ConvertInvariant<decimal>()
+					};
+					book.Bids[depth.Price] = depth;
+				}
+			}
+			else
+			{
+				Logger.Error($"No bids in {nameof(ParseOrderBookFromJTokenArrays)}");
 			}
 
 			return book;


### PR DESCRIPTION
1. Updated rate gate settings for KuCoin from a 60s delay for every 20 requests to 1s delay for every 60 requests (in the docs, I've seen they allow 2000 reqs / 30s for public endpoints).
2. Moved orderbook initialization before creating the WS connection, mainly so that the caller of `OnGetDeltaOrderBookWebSocketAsync` has to wait for how long it actually takes to subscribe
3. Added a useful log for MEXC, when the WS connection is rejected
4. Made it so if there is a failure in the creation of the snapshot orderbook, it does not cause an error that interrupts the whole process and makes it start over (it now just logs)