### PR TITLE
Fix MEXC OnGetTickersAsync

### DIFF
--- a/src/ExchangeSharp/API/Exchanges/MEXC/ExchangeMEXCAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/MEXC/ExchangeMEXCAPI.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using ExchangeSharp.Models;
@@ -94,6 +95,9 @@ namespace ExchangeSharp
 							timestampKey: "closeTime")));
 				}
 				catch (OverflowException)
+				{
+				}
+				catch (InvalidDataException)
 				{
 				}
 			}


### PR DESCRIPTION
OnGetTickersAsync throws InvalidDataException when new trading pair is added to the ticker, but it is missing in our ExchangeMarket cache. Same as #785