### PR TITLE
fix: GetExchangeApi generic resolves T

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The following cryptocurrency services are supported:
 
 Exchange constructors are private, to get access to an exchange in code use:
 
-`ExchangeAPI.GetExchangeAPIAsync<>()`.
+`ExchangeAPI.GetExchangeAPIAsync<T>()`.
 
 ### Installing the CLI
 

--- a/src/ExchangeSharp/API/Exchanges/_Base/ExchangeAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/_Base/ExchangeAPI.cs
@@ -605,19 +605,20 @@ namespace ExchangeSharp
 		/// <typeparam name="T">Type of exchange to get</typeparam>
 		/// <returns>Exchange API or null if not found</returns>
 		[Obsolete("Use the async version")]
-		public static IExchangeAPI GetExchangeAPI<T>()
+		public static T GetExchangeAPI<T>()
 				where T : ExchangeAPI
 		{
 			return GetExchangeAPIAsync<T>().Result;
 		}
 
-		public static Task<IExchangeAPI> GetExchangeAPIAsync<T>()
+		public static async Task<T> GetExchangeAPIAsync<T>()
 				where T : ExchangeAPI
 		{
 			// note: this method will be slightly slow (milliseconds) the first time it is called due to cache miss and initialization
 			// subsequent calls with cache hits will be nanoseconds
 			Type type = typeof(T)!;
-			return GetExchangeAPIAsync(type);
+
+			return (T)await GetExchangeAPIAsync(type);
 		}
 
 		/// <summary>

--- a/tests/ExchangeSharpTests/ExchangeBinanceAPITests.cs
+++ b/tests/ExchangeSharpTests/ExchangeBinanceAPITests.cs
@@ -34,22 +34,22 @@ namespace ExchangeSharpTests
 			string toParse =
 					@"{
   ""e"": ""depthUpdate"",
-  ""E"": 123456789,    
-  ""s"": ""BNBBTC"",     
-  ""U"": 157,          
-  ""u"": 160,          
-  ""b"": [             
+  ""E"": 123456789,
+  ""s"": ""BNBBTC"",
+  ""U"": 157,
+  ""u"": 160,
+  ""b"": [
     [
-      ""0.0024"",      
+      ""0.0024"",
       ""10"",
-      []             
+      []
     ]
   ],
-  ""a"": [             
+  ""a"": [
     [
-      ""0.0026"",      
-      ""100"",         
-      []             
+      ""0.0026"",
+      ""100"",
+      []
     ]
   ]
 }";
@@ -116,7 +116,7 @@ namespace ExchangeSharpTests
 			requestMaker
 					.MakeRequestAsync(
 							"/capital/config/getall",
-							((ExchangeBinanceAPI)binance).BaseUrlSApi
+							binance.BaseUrlSApi
 					)
 					.Returns(
 							new IAPIRequestMaker.RequestResult<string>()

--- a/tests/ExchangeSharpTests/ExchangeMEXCAPITests.cs
+++ b/tests/ExchangeSharpTests/ExchangeMEXCAPITests.cs
@@ -11,7 +11,7 @@ namespace ExchangeSharpTests;
 public class MEXCAPITests
 {
 	private const string MarketSymbol = "ETHBTC";
-	private static IExchangeAPI _api;
+	private static ExchangeMEXCAPI _api;
 
 	[AssemblyInitialize]
 	public static async Task AssemblyInitialize(TestContext testContext)


### PR DESCRIPTION
Minor modification to the typings returned by the generic get exchange methods to return T instead of IExchangeApi.